### PR TITLE
DirectGuiDesigner Support

### DIFF
--- a/DesignerWidgets/DirectAutoSizer.widget
+++ b/DesignerWidgets/DirectAutoSizer.widget
@@ -4,54 +4,54 @@
     "moduleName":"DirectAutoSizer",
     "displayName":"Auto Sizer",
     "className":"DirectAutoSizer",
-    "classfilePath":"DirectGuiExtension.DirectAutoSizer",
+    "classFilePath":"DirectGuiExtension.DirectAutoSizer",
     "customProperties":[
         {
-            "visiblename":"Refresh sizer",
+            "displayName":"Refresh sizer",
             "internalName":"refresh",
             "internalType":"function",
             "editType":"command",
             "valueOptions":"refresh"
         },
         {
-            "visiblename":"Extend Horizontal",
+            "displayName":"Extend Horizontal",
             "internalName":"extendHorizontal",
             "internalType":"bool"
         },
         {
-            "visiblename":"Extend Vertical",
+            "displayName":"Extend Vertical",
             "internalName":"extendVertical",
             "internalType":"bool"
         },
         {
-            "visiblename":"Update on window resize",
+            "displayName":"Update on window resize",
             "internalName":"updateOnWindowResize",
             "internalType":"bool"
         },
         {
-            "visiblename":"Minimum size",
+            "displayName":"Minimum size",
             "internalName":"minSize",
             "internalType":"int",
             "editType":"base4"
         },
         {
-            "visiblename":"Maximum size",
+            "displayName":"Maximum size",
             "internalName":"maxSize",
             "internalType":"int",
             "editType":"base4"
         },
         {
-            "visiblename":"Child size update function",
+            "displayName":"Child size update function",
             "internalName":"childUpdateSizeFunc",
             "internalType":"function"
         },
         {
-            "visiblename":"Function returning the size of the parent",
+            "displayName":"Function returning the size of the parent",
             "internalName":"parentGetSizeFunction",
             "internalType":"function"
         },
         {
-            "visiblename":"Extra arguments for the function returning the size of the parent",
+            "displayName":"Extra arguments for the function returning the size of the parent",
             "internalName":"parentGetSizeExtraArgs",
             "internalType":"function"
         }],

--- a/DesignerWidgets/DirectAutoSizer.widget
+++ b/DesignerWidgets/DirectAutoSizer.widget
@@ -1,56 +1,59 @@
 {
     "name":"DirectAutoSizer",
+    "baseWidget":"DirectFrame",
     "moduleName":"DirectAutoSizer",
     "displayName":"Auto Sizer",
     "className":"DirectAutoSizer",
     "classfilePath":"DirectGuiExtension.DirectAutoSizer",
-    "enabledProperties":[""],
     "customProperties":[
         {
-            "displayName":"Refresh sizer",
-            "propertyName":"refresh",
-            "propertyType":"command",
-            "customCommandName":"refresh"
+            "visiblename":"Refresh sizer",
+            "internalName":"refresh",
+            "internalType":"function",
+            "editType":"command",
+            "valueOptions":"refresh"
         },
         {
-            "displayName":"Extend Horizontal",
-            "propertyName":"extendHorizontal",
-            "propertyType":"bool"
+            "visiblename":"Extend Horizontal",
+            "internalName":"extendHorizontal",
+            "internalType":"bool"
         },
         {
-            "displayName":"Extend Vertical",
-            "propertyName":"extendVertical",
-            "propertyType":"bool"
+            "visiblename":"Extend Vertical",
+            "internalName":"extendVertical",
+            "internalType":"bool"
         },
         {
-            "displayName":"Update on window resize",
-            "propertyName":"updateOnWindowResize",
-            "propertyType":"bool"
+            "visiblename":"Update on window resize",
+            "internalName":"updateOnWindowResize",
+            "internalType":"bool"
         },
         {
-            "displayName":"Minimum size",
-            "propertyName":"minSize",
-            "propertyType":"vbase4"
+            "visiblename":"Minimum size",
+            "internalName":"minSize",
+            "internalType":"int",
+            "editType":"base4"
         },
         {
-            "displayName":"Maximum size",
-            "propertyName":"maxSize",
-            "propertyType":"vbase4"
+            "visiblename":"Maximum size",
+            "internalName":"maxSize",
+            "internalType":"int",
+            "editType":"base4"
         },
         {
-            "displayName":"Child size update function",
-            "propertyName":"childUpdateSizeFunc",
-            "propertyType":"commandProperty"
+            "visiblename":"Child size update function",
+            "internalName":"childUpdateSizeFunc",
+            "internalType":"function"
         },
         {
-            "displayName":"Function returning the size of the parent",
-            "propertyName":"parentGetSizeFunction",
-            "propertyType":"commandProperty"
+            "visiblename":"Function returning the size of the parent",
+            "internalName":"parentGetSizeFunction",
+            "internalType":"function"
         },
         {
-            "displayName":"Extra arguments for the function returning the size of the parent",
-            "propertyName":"parentGetSizeExtraArgs",
-            "propertyType":"commandProperty"
+            "visiblename":"Extra arguments for the function returning the size of the parent",
+            "internalName":"parentGetSizeExtraArgs",
+            "internalType":"function"
         }],
     "addItemFunctionName":"setChild",
     "removeItemFunctionName":"removeChild",

--- a/DesignerWidgets/DirectBoxSizer.widget
+++ b/DesignerWidgets/DirectBoxSizer.widget
@@ -1,34 +1,42 @@
 {
     "name":"DirectBoxSizer",
+    "baseWidget":"DirectFrame",
     "moduleName":"DirectBoxSizer",
     "displayName":"Box Sizer",
     "className":"DirectBoxSizer",
     "classfilePath":"DirectGuiExtension.DirectBoxSizer",
-    "enabledProperties":["orientation"],
     "customProperties":[
         {
-            "displayName":"Refresh position",
-            "propertyName":"refresh",
-            "propertyType":"command",
-            "customCommandName":"refresh"
+            "visiblename":"Item Alignment",
+            "internalName":"itemAlign",
+            "internalType":"str",
+            "editType":"optionmenu",
+            "valueOptions":{"Center":1, "Left":2, "Right":4, "Middle":8, "Top":16, "Bottom":32, "Center/Middle":9, "Center/Top":17, "Center/Bottom":33, "Left/Middle":10, "Left/Top":18, "Left/Bottom":34, "Right/Middle":12, "Right/Top":20, "Right/Bottom":36}
         },
         {
-            "displayName":"Item Margin",
-            "propertyName":"itemMargin",
-            "propertyType":"vbase4"
+            "visiblename":"Refresh position",
+            "internalName":"refresh",
+            "editType":"command",
+            "valueOptions":"refresh"
         },
         {
-            "displayName":"Item Alignment",
-            "propertyName":"itemAlign",
-            "propertyType":"selection",
-            "customSelectionDict":{"Center":1, "Left":2, "Right":4, "Middle":8, "Top":16, "Bottom":32, "Center/Middle":9, "Center/Top":17, "Center/Bottom":33, "Left/Middle":10, "Left/Top":18, "Left/Bottom":34, "Right/Middle":12, "Right/Top":20, "Right/Bottom":36}
+            "visiblename":"Item Margin",
+            "internalName":"itemMargin",
+            "internalType":"int",
+            "editType":"base4"
         },
         {
-            "displayName":"Update Framesize with items",
-            "propertyName":"autoUpdateFrameSize",
-            "propertyType":"bool"
+            "visiblename":"Orientation",
+            "internalName":"orientation",
+            "editType":"optionmenu",
+            "valueOptions":{"Horizontal":"horizontal", "Horizontal Inverted":"horizontal_inverted", "Vertical":"vertical", "Vertical Inverted":"vertical_inverted"}
+        },
+        {
+            "visiblename":"Update Framesize with items",
+            "internalName":"autoUpdateFrameSize",
+            "editType":"bool"
         }],
     "addItemFunctionName":"addItem",
     "removeItemFunctionName":"removeItem",
-    "importPath":"from customWidgetSample.DirectBoxSizer import DirectBoxSizer"
+    "importPath":"from DirectGuiExtension.DirectBoxSizer import DirectBoxSizer"
 }

--- a/DesignerWidgets/DirectBoxSizer.widget
+++ b/DesignerWidgets/DirectBoxSizer.widget
@@ -4,35 +4,35 @@
     "moduleName":"DirectBoxSizer",
     "displayName":"Box Sizer",
     "className":"DirectBoxSizer",
-    "classfilePath":"DirectGuiExtension.DirectBoxSizer",
+    "classFilePath":"DirectGuiExtension.DirectBoxSizer",
     "customProperties":[
         {
-            "visiblename":"Item Alignment",
+            "displayName":"Item Alignment",
             "internalName":"itemAlign",
             "internalType":"str",
-            "editType":"optionmenu",
+            "editType":"optionMenu",
             "valueOptions":{"Center":1, "Left":2, "Right":4, "Middle":8, "Top":16, "Bottom":32, "Center/Middle":9, "Center/Top":17, "Center/Bottom":33, "Left/Middle":10, "Left/Top":18, "Left/Bottom":34, "Right/Middle":12, "Right/Top":20, "Right/Bottom":36}
         },
         {
-            "visiblename":"Refresh position",
+            "displayName":"Refresh position",
             "internalName":"refresh",
             "editType":"command",
             "valueOptions":"refresh"
         },
         {
-            "visiblename":"Item Margin",
+            "displayName":"Item Margin",
             "internalName":"itemMargin",
             "internalType":"int",
             "editType":"base4"
         },
         {
-            "visiblename":"Orientation",
+            "displayName":"Orientation",
             "internalName":"orientation",
-            "editType":"optionmenu",
+            "editType":"optionMenu",
             "valueOptions":{"Horizontal":"horizontal", "Horizontal Inverted":"horizontal_inverted", "Vertical":"vertical", "Vertical Inverted":"vertical_inverted"}
         },
         {
-            "visiblename":"Update Framesize with items",
+            "displayName":"Update Framesize with items",
             "internalName":"autoUpdateFrameSize",
             "editType":"bool"
         }],

--- a/DesignerWidgets/DirectCollapsibleFrame.widget
+++ b/DesignerWidgets/DirectCollapsibleFrame.widget
@@ -41,7 +41,5 @@
         "defaultPixel": [-100, 100, -100, 100]
         }
     ],
-    "//addItemFunctionName":"addItem",
-    "//removeItemFunctionName":"removeItem",
     "importPath":"from DirectGuiExtension.DirectCollapsibleFrame import DirectCollapsibleFrame"
 }

--- a/DesignerWidgets/DirectCollapsibleFrame.widget
+++ b/DesignerWidgets/DirectCollapsibleFrame.widget
@@ -1,0 +1,42 @@
+{
+    "name":"DirectCollapsibleFrame",
+    "baseWidget":"DirectFrame",
+    "moduleName":"DirectCollapsibleFrame",
+    "displayName":"Collapsible Frame",
+    "className":"DirectCollapsibleFrame",
+    "classFilePath":"DirectGuiExtension.DirectCollapsibleFrame",
+    "customProperties":[
+        {
+            "displayName":"Header Height",
+            "internalName":"headerheight",
+            "editType":"float",
+            "postProcessFunctionName": "setCollapsed"
+        },
+        {
+            "displayName":"Collapsed",
+            "internalName":"collapsed",
+            "editType":"bool"
+        },
+        {
+            "displayName":"Collapse Text",
+            "internalName":"collapseText",
+            "editType":"str",
+            "postProcessFunctionName": "setCollapsed"
+        },
+        {
+            "displayName":"Extend Text",
+            "internalName":"extendText",
+            "editType":"str",
+            "postProcessFunctionName": "setCollapsed"
+        },
+        {
+            "displayName":"Update Frame Size",
+            "internalName":"updateFrameSize",
+            "editType":"command",
+            "valueOptions": "updateFrameSize"
+        }
+    ],
+    "//addItemFunctionName":"addItem",
+    "//removeItemFunctionName":"removeItem",
+    "importPath":"from DirectGuiExtension.DirectCollapsibleFrame import DirectCollapsibleFrame"
+}

--- a/DesignerWidgets/DirectCollapsibleFrame.widget
+++ b/DesignerWidgets/DirectCollapsibleFrame.widget
@@ -10,7 +10,8 @@
             "displayName":"Header Height",
             "internalName":"headerheight",
             "editType":"float",
-            "postProcessFunctionName": "setCollapsed"
+            "postProcessFunctionName": "setCollapsed",
+            "defaultPixel": 20
         },
         {
             "displayName":"Collapsed",
@@ -34,6 +35,10 @@
             "internalName":"updateFrameSize",
             "editType":"command",
             "valueOptions": "updateFrameSize"
+        },
+        {
+        "internalName": "frameSize",
+        "defaultPixel": [-100, 100, -100, 100]
         }
     ],
     "//addItemFunctionName":"addItem",

--- a/DesignerWidgets/DirectDatePicker.widget
+++ b/DesignerWidgets/DirectDatePicker.widget
@@ -35,6 +35,10 @@
             "displayName":"Today Frame Color",
             "internalName":"todayFrameColor",
             "editType":"base4"
+        },
+        {
+        "internalName": "scale",
+        "defaultPixel": 200
         }
     ],
     "importPath":"from DirectGuiExtension.DirectDatePicker import DirectDatePicker"

--- a/DesignerWidgets/DirectDatePicker.widget
+++ b/DesignerWidgets/DirectDatePicker.widget
@@ -4,25 +4,38 @@
     "moduleName":"DirectDatePicker",
     "displayName":"Calendar",
     "className":"DirectDatePicker",
-    "classfilePath":"DirectGuiExtension.DirectDatePicker",
-    "enabledProperties":[],
+    "classFilePath":"DirectGuiExtension.DirectDatePicker",
     "customProperties":[
         {
-            "visiblename":"Year",
+            "displayName":"Year",
             "internalName":"year",
             "editType":"int"
         },
         {
-            "visiblename":"Month",
+            "displayName":"Month",
             "internalName":"month",
             "editType":"int"
         },
         {
-            "visiblename":"Day",
+            "displayName":"Day",
             "internalName":"day",
             "editType":"int"
-        }],
-    "addItemFunctionName":"",
-    "removeItemFunctionName":"",
+        },
+        {
+            "displayName":"Normal Day Frame Color",
+            "internalName":"normalDayFrameColor",
+            "editType":"base4"
+        },
+        {
+            "displayName":"Active Day Frame Color",
+            "internalName":"activeDayFrameColor",
+            "editType":"base4"
+        },
+        {
+            "displayName":"Today Frame Color",
+            "internalName":"todayFrameColor",
+            "editType":"base4"
+        }
+    ],
     "importPath":"from DirectGuiExtension.DirectDatePicker import DirectDatePicker"
 }

--- a/DesignerWidgets/DirectDatePicker.widget
+++ b/DesignerWidgets/DirectDatePicker.widget
@@ -1,5 +1,6 @@
 {
     "name":"DirectDatePicker",
+    "baseWidget":"DirectGridSizer",
     "moduleName":"DirectDatePicker",
     "displayName":"Calendar",
     "className":"DirectDatePicker",
@@ -7,19 +8,19 @@
     "enabledProperties":[],
     "customProperties":[
         {
-            "displayName":"Year",
-            "propertyName":"year",
-            "propertyType":"int"
+            "visiblename":"Year",
+            "internalName":"year",
+            "editType":"int"
         },
         {
-            "displayName":"Month",
-            "propertyName":"month",
-            "propertyType":"int"
+            "visiblename":"Month",
+            "internalName":"month",
+            "editType":"int"
         },
         {
-            "displayName":"Day",
-            "propertyName":"day",
-            "propertyType":"int"
+            "visiblename":"Day",
+            "internalName":"day",
+            "editType":"int"
         }],
     "addItemFunctionName":"",
     "removeItemFunctionName":"",

--- a/DesignerWidgets/DirectDiagram.widget
+++ b/DesignerWidgets/DirectDiagram.widget
@@ -76,6 +76,10 @@
             "internalName":"refresh",
             "editType":"command",
             "valueOptions":"refresh"
+        },
+        {
+            "internalName": "frameSize",
+            "defaultPixel": [-100, 100, -100, 100]
         }
     ],
     "importPath":"from DirectGuiExtension.DirectDiagram import DirectDiagram"

--- a/DesignerWidgets/DirectDiagram.widget
+++ b/DesignerWidgets/DirectDiagram.widget
@@ -1,18 +1,24 @@
 {
-    "name":"",
-    "moduleName":"",
-    "displayName":"",
-    "className":"",
-    "classfilePath":"",
-    "enabledProperties":[""],
+    "name":"DirectDiagram",
+    "baseWidget":"DirectFrame",
+    "moduleName":"DirectDiagram",
+    "displayName":"Diagram",
+    "className":"DirectDiagram",
+    "classfilePath":"DirectGuiExtension.DirectDiagram",
     "customProperties":[
         {
-            "displayName":"Refresh position",
-            "propertyName":"refresh",
-            "propertyType":"command",
-            "customCommandName":"refresh"
+            "visiblename":"Data",
+            "internalName":"data",
+            "editType":"list",
+            "setFunctionName":"setData"
+        },
+        {
+            "visiblename":"Refresh position",
+            "internalName":"refresh",
+            "editType":"command",
+            "valueOptions":"refresh"
         }],
-    "addItemFunctionName":"",
-    "removeItemFunctionName":"",
-    "importPath":"from DirectGuiExtension.Direct import Direct"
+    "//addItemFunctionName":"",
+    "//removeItemFunctionName":"",
+    "importPath":"from DirectGuiExtension.DirectDiagram import DirectDiagram"
 }

--- a/DesignerWidgets/DirectDiagram.widget
+++ b/DesignerWidgets/DirectDiagram.widget
@@ -4,21 +4,79 @@
     "moduleName":"DirectDiagram",
     "displayName":"Diagram",
     "className":"DirectDiagram",
-    "classfilePath":"DirectGuiExtension.DirectDiagram",
+    "classFilePath":"DirectGuiExtension.DirectDiagram",
     "customProperties":[
         {
-            "visiblename":"Data",
+            "displayName":"Data",
             "internalName":"data",
             "editType":"list",
             "setFunctionName":"setData"
         },
         {
-            "visiblename":"Refresh position",
+            "displayName":"Num Pos Steps",
+            "internalName":"numPosSteps",
+            "editType":"int"
+        },
+        {
+            "displayName":"Num Pos Steps Step",
+            "internalName":"numPosStepsStep",
+            "editType":"int"
+        },
+        {
+            "displayName":"Num Neg Steps",
+            "internalName":"numNegSteps",
+            "editType":"int"
+        },
+        {
+            "displayName":"Num Neg Steps Step",
+            "internalName":"numNegStepsStep",
+            "editType":"int"
+        },
+        {
+            "displayName":"Num Text Scale",
+            "internalName":"numtextScale",
+            "editType":"float"
+        },
+        {
+            "displayName":"Show Data Numbers",
+            "internalName":"showDataNumbers",
+            "editType":"bool"
+        },
+        {
+            "displayName":"Data Num Text Scale",
+            "internalName":"dataNumtextScale",
+            "editType":"float"
+        },
+        {
+            "displayName":"Data Num Text Scale",
+            "internalName":"dataNumtextScale",
+            "editType":"float"
+        },
+        {
+            "displayName":"Step Accuracy",
+            "internalName":"stepAccuracy",
+            "editType":"int"
+        },
+        {
+            "displayName":"Step Format",
+            "internalName":"stepFormat",
+            "editType":"optionMenu",
+            "valueOptions":{"int":"int", "float":"float"},
+            "loaderFunc": "eval(value)",
+            "addToExtraOptions": true,
+            "canGetValueFromElement": false
+        },
+        {
+            "displayName":"Number Area Width",
+            "internalName":"numberAreaWidth",
+            "editType":"float"
+        },
+        {
+            "displayName":"Refresh position",
             "internalName":"refresh",
             "editType":"command",
             "valueOptions":"refresh"
-        }],
-    "//addItemFunctionName":"",
-    "//removeItemFunctionName":"",
+        }
+    ],
     "importPath":"from DirectGuiExtension.DirectDiagram import DirectDiagram"
 }

--- a/DesignerWidgets/DirectGridSizer.widget
+++ b/DesignerWidgets/DirectGridSizer.widget
@@ -44,11 +44,11 @@
     "addItemExtraArgs": {
         "row": {
             "type": "int",
-            "defaultValue": 1
+            "defaultValue": 0
         },
         "column": {
             "type": "int",
-            "defaultValue": 1
+            "defaultValue": 0
         },
         "widthInColumns": {
             "type": "int",

--- a/DesignerWidgets/DirectGridSizer.widget
+++ b/DesignerWidgets/DirectGridSizer.widget
@@ -40,7 +40,6 @@
         }
     ],
     "addItemFunctionName": "addItem",
-    "//addItemExtraArgs": [1, 1],
     "addItemExtraArgs": {
         "row": {
             "type": "int",

--- a/DesignerWidgets/DirectGridSizer.widget
+++ b/DesignerWidgets/DirectGridSizer.widget
@@ -1,43 +1,44 @@
 {
     "name":"DirectGridSizer",
+    "baseWidget":"DirectFrame",
     "moduleName":"DirectGridSizer",
     "displayName":"Grid Sizer",
     "className":"DirectGridSizer",
     "classfilePath":"DirectGuiExtension.DirectGridSizer",
-    "enabledProperties":[""],
     "customProperties":[
         {
-            "displayName":"Refresh position",
-            "propertyName":"refresh",
-            "propertyType":"command",
-            "customCommandName":"refresh"
+            "visiblename":"Align ",
+            "internalName":"boxAlign",
+            "editType":"optionmenu",
+            "valueOptions":{"Left":"left", "Right":"right"}
         },
         {
-            "displayName":"Item Margin",
-            "propertyName":"itemMargin",
-            "propertyType":"vbase4"
+            "visiblename":"Refresh position",
+            "internalName":"refresh",
+            "editType":"command",
+            "valueOptions":"refresh"
         },
         {
-            "displayName":"Number of Rows",
-            "propertyName":"numRows",
-            "propertyType":"int"
+            "visiblename":"Item Margin",
+            "internalName":"itemMargin",
+            "editType":"base4"
         },
         {
-            "displayName":"Number of Columns",
-            "propertyName":"numColumns",
-            "propertyType":"int"
+            "visiblename":"Number of Rows",
+            "internalName":"numRows",
+            "editType":"integer"
         },
         {
-            "displayName":"Update Framesize with items",
-            "propertyName":"autoUpdateFrameSize",
-            "propertyType":"bool"
+            "visiblename":"Number of Columns",
+            "internalName":"numColumns",
+            "editType":"integer"
         },
         {
-            "displayName":"Align ",
-            "propertyName":"boxAlign",
-            "propertyType":"align"
+            "visiblename":"Update Framesize with items",
+            "internalName":"autoUpdateFrameSize",
+            "editType":"bool"
         }],
     "addItemFunctionName":"addItem",
     "removeItemFunctionName":"removeItem",
-    "importPath":"from customWidgetSample.DirectGridSizer import DirectGridSizer"
+    "importPath":"from DirectGuiExtension.DirectGridSizer import DirectGridSizer"
 }

--- a/DesignerWidgets/DirectGridSizer.widget
+++ b/DesignerWidgets/DirectGridSizer.widget
@@ -1,44 +1,64 @@
 {
-    "name":"DirectGridSizer",
-    "baseWidget":"DirectFrame",
-    "moduleName":"DirectGridSizer",
-    "displayName":"Grid Sizer",
-    "className":"DirectGridSizer",
-    "classfilePath":"DirectGuiExtension.DirectGridSizer",
-    "customProperties":[
+    "name": "DirectGridSizer",
+    "baseWidget": "DirectFrame",
+    "moduleName": "DirectGridSizer",
+    "displayName": "Grid Sizer",
+    "className": "DirectGridSizer",
+    "classFilePath": "DirectGuiExtension.DirectGridSizer",
+    "customProperties": [
         {
-            "visiblename":"Align ",
-            "internalName":"boxAlign",
-            "editType":"optionmenu",
-            "valueOptions":{"Left":"left", "Right":"right"}
+            "displayName": "Align",
+            "internalName": "boxAlign",
+            "editType": "optionMenu",
+            "valueOptions": {"Left": "left", "Right": "right"}
         },
         {
-            "visiblename":"Refresh position",
-            "internalName":"refresh",
-            "editType":"command",
-            "valueOptions":"refresh"
+            "displayName": "Refresh position",
+            "internalName": "refresh",
+            "editType": "command",
+            "valueOptions": "refresh"
         },
         {
-            "visiblename":"Item Margin",
-            "internalName":"itemMargin",
-            "editType":"base4"
+            "displayName": "Item Margin",
+            "internalName": "itemMargin",
+            "editType": "base4"
         },
         {
-            "visiblename":"Number of Rows",
-            "internalName":"numRows",
-            "editType":"integer"
+            "displayName": "Number of Rows",
+            "internalName": "numRows",
+            "editType": "int"
         },
         {
-            "visiblename":"Number of Columns",
-            "internalName":"numColumns",
-            "editType":"integer"
+            "displayName": "Number of Columns",
+            "internalName": "numColumns",
+            "editType": "int"
         },
         {
-            "visiblename":"Update Framesize with items",
-            "internalName":"autoUpdateFrameSize",
-            "editType":"bool"
-        }],
-    "addItemFunctionName":"addItem",
-    "removeItemFunctionName":"removeItem",
-    "importPath":"from DirectGuiExtension.DirectGridSizer import DirectGridSizer"
+            "displayName": "Update Framesize with items",
+            "internalName": "autoUpdateFrameSize",
+            "editType": "bool"
+        }
+    ],
+    "addItemFunctionName": "addItem",
+    "//addItemExtraArgs": [1, 1],
+    "addItemExtraArgs": {
+        "row": {
+            "type": "int",
+            "defaultValue": 1
+        },
+        "column": {
+            "type": "int",
+            "defaultValue": 1
+        },
+        "widthInColumns": {
+            "type": "int",
+            "defaultValue": 1
+        },
+        "heightInRows": {
+            "type": "int",
+            "defaultValue": 1
+        }
+    },
+    "removeItemFunctionName": "removeItem",
+    "importPath": "from DirectGuiExtension.DirectGridSizer import DirectGridSizer"
 }

--- a/DesignerWidgets/DirectMenuBar.widget
+++ b/DesignerWidgets/DirectMenuBar.widget
@@ -1,0 +1,20 @@
+{
+    "name":"DirectMenuBar",
+    "baseWidget":"DirectBoxSizer",
+    "moduleName":"DirectMenuBar",
+    "displayName":"Menu Bar",
+    "className":"DirectMenuBar",
+    "classFilePath":"DirectGuiExtension.DirectMenuBar",
+    "customProperties":[
+        {
+            "displayName":"Menu Items",
+            "internalName":"menuItems",
+            "editType":"list",
+            "postProcessFunctionName": "setItems"
+        }
+    ],
+    "addItemFunctionName":"addItem",
+    "removeItemFunctionName":"removeItem",
+    "//addItemNode": "firstFrame",
+    "importPath":"from DirectGuiExtension.DirectMenuBar import DirectMenuBar"
+}

--- a/DesignerWidgets/DirectMenuBar.widget
+++ b/DesignerWidgets/DirectMenuBar.widget
@@ -15,6 +15,5 @@
     ],
     "addItemFunctionName":"addItem",
     "removeItemFunctionName":"removeItem",
-    "//addItemNode": "firstFrame",
     "importPath":"from DirectGuiExtension.DirectMenuBar import DirectMenuBar"
 }

--- a/DesignerWidgets/DirectMenuItem.widget
+++ b/DesignerWidgets/DirectMenuItem.widget
@@ -35,7 +35,5 @@
             "editType":"base4"
         }
     ],
-    "//addItemFunctionName":"",
-    "//removeItemFunctionName":"",
     "importPath":"from DirectGuiExtension.DirectMenuItem import DirectMenuItem"
 }

--- a/DesignerWidgets/DirectMenuItem.widget
+++ b/DesignerWidgets/DirectMenuItem.widget
@@ -4,20 +4,37 @@
     "moduleName":"DirectMenuItem",
     "displayName":"Menu Item",
     "className":"DirectMenuItem",
-    "classfilePath":"DirectGuiExtension.DirectMenuItem",
-    "enabledProperties":["text"],
+    "classFilePath":"DirectGuiExtension.DirectMenuItem",
     "customProperties":[
         {
-            "visiblename":"Popup Location",
+            "displayName":"Items",
+            "internalName":"items",
+            "editType":"list",
+            "internalType": "list",
+            "postProcessFunctionName": "setItems"
+        },
+        {
+            "displayName":"Popup Location",
             "internalName":"popupMenuLocation",
-            "editType":"optionmenu",
+            "editType":"optionMenu",
             "valueOptions":{"Left":"left", "Right":"right", "Above":"above", "Below":"below"}
         },
         {
-            "visiblename":"Highlight Color",
+            "displayName":"Highlight Color",
             "internalName":"highlightColor",
             "editType":"base4"
-        }],
+        },
+        {
+            "displayName":"Item Frame Color",
+            "internalName":"itemFrameColor",
+            "editType":"base4"
+        },
+        {
+            "displayName":"Separator Frame Color",
+            "internalName":"separatorFrameColor",
+            "editType":"base4"
+        }
+    ],
     "//addItemFunctionName":"",
     "//removeItemFunctionName":"",
     "importPath":"from DirectGuiExtension.DirectMenuItem import DirectMenuItem"

--- a/DesignerWidgets/DirectMenuItem.widget
+++ b/DesignerWidgets/DirectMenuItem.widget
@@ -1,5 +1,6 @@
 {
     "name":"DirectMenuItem",
+    "baseWidget":"DirectButton",
     "moduleName":"DirectMenuItem",
     "displayName":"Menu Item",
     "className":"DirectMenuItem",
@@ -7,17 +8,17 @@
     "enabledProperties":["text"],
     "customProperties":[
         {
-            "displayName":"Popup Location",
-            "propertyName":"popupMenuLocation",
-            "propertyType":"selection",
-            "customSelectionDict":{"Left":"left", "Right":"right", "Above":"above", "Below":"below"}
+            "visiblename":"Popup Location",
+            "internalName":"popupMenuLocation",
+            "editType":"optionmenu",
+            "valueOptions":{"Left":"left", "Right":"right", "Above":"above", "Below":"below"}
         },
         {
-            "displayName":"Highlight Color",
-            "propertyName":"highlightColor",
-            "propertyType":"vbase4"
+            "visiblename":"Highlight Color",
+            "internalName":"highlightColor",
+            "editType":"base4"
         }],
-    "addItemFunctionName":"",
-    "removeItemFunctionName":"",
+    "//addItemFunctionName":"",
+    "//removeItemFunctionName":"",
     "importPath":"from DirectGuiExtension.DirectMenuItem import DirectMenuItem"
 }

--- a/DesignerWidgets/DirectOptionMenu.widget
+++ b/DesignerWidgets/DirectOptionMenu.widget
@@ -41,7 +41,5 @@
             "editType":"base2"
         }
     ],
-    "//addItemFunctionName":"add_tab",
-    "//removeItemFunctionName":"close_tab",
     "importPath":"from DirectGuiExtension.DirectOptionMenu import DirectOptionMenu"
 }

--- a/DesignerWidgets/DirectOptionMenu.widget
+++ b/DesignerWidgets/DirectOptionMenu.widget
@@ -1,5 +1,5 @@
 {
-    "name":"DirectOptionMenu",
+    "/name":"DirectOptionMenu",
     "baseWidget":"DirectFrame",
     "moduleName":"DirectOptionMenu",
     "displayName":"Option Menu",
@@ -10,7 +10,8 @@
             "displayName":"Items",
             "internalName":"items",
             "editType":"list",
-            "postProcessFunctionName": "setItems"
+            "postProcessFunctionName": "setItems",
+            "defaultValue": ["Item1"]
         },
         {
             "displayName":"Initial Item",

--- a/DesignerWidgets/DirectOptionMenu.widget
+++ b/DesignerWidgets/DirectOptionMenu.widget
@@ -1,0 +1,46 @@
+{
+    "name":"DirectOptionMenu",
+    "baseWidget":"DirectFrame",
+    "moduleName":"DirectOptionMenu",
+    "displayName":"Option Menu",
+    "className":"DirectOptionMenu",
+    "classFilePath":"DirectGuiExtension.DirectOptionMenu",
+    "customProperties":[
+        {
+            "displayName":"Items",
+            "internalName":"items",
+            "editType":"list",
+            "postProcessFunctionName": "setItems"
+        },
+        {
+            "displayName":"Initial Item",
+            "internalName":"initialitem",
+            "editType":"int",
+            "isInitOption": true
+        },
+        {
+            "displayName":"Popup Marker Border",
+            "internalName":"popupMarkerBorder",
+            "editType":"base2"
+        },
+        {
+            "displayName":"Popup Menu Location",
+            "internalName":"popupMenuLocation",
+            "editType":"optionMenu",
+            "valueOptions":{"Left":"left", "Right":"right", "Above":"above", "Below":"below"}
+        },
+        {
+            "displayName":"Highlight Color",
+            "internalName":"highlightColor",
+            "editType":"base4"
+        },
+        {
+            "displayName":"Highlight Scale",
+            "internalName":"highlightScale",
+            "editType":"base2"
+        }
+    ],
+    "//addItemFunctionName":"add_tab",
+    "//removeItemFunctionName":"close_tab",
+    "importPath":"from DirectGuiExtension.DirectOptionMenu import DirectOptionMenu"
+}

--- a/DesignerWidgets/DirectScrolledWindowFrame.widget
+++ b/DesignerWidgets/DirectScrolledWindowFrame.widget
@@ -4,35 +4,35 @@
     "moduleName":"DirectScrolledWindowFrame",
     "displayName":"Scrolled Window Frame",
     "className":"DirectScrolledWindowFrame",
-    "classfilePath":"DirectGuiExtension.DirectScrolledWindowFrame",
+    "classFilePath":"DirectGuiExtension.DirectScrolledWindowFrame",
     "customProperties":[
         {
-            "visiblename":"Drag Area Height",
+            "displayName":"Drag Area Height",
             "internalName":"dragAreaHeight",
             "editType":"float"
         },
         {
-            "visiblename":"Resort z-order on drag",
+            "displayName":"Resort z-order on drag",
             "internalName":"resortOnDrag",
             "editType":"bool"
         },
         {
-            "visiblename":"Show Close Button",
+            "displayName":"Show Close Button",
             "internalName":"showClose",
             "editType":"bool"
         },
         {
-            "visiblename":"Close Button Position",
+            "displayName":"Close Button Position",
             "internalName":"closeButtonPosition",
-            "editType":"optionmenu",
+            "editType":"optionMenu",
             "valueOptions":{"Left":"Left", "Right":"Right"}
         },
         {
-            "visiblename":"Close Button scale",
+            "displayName":"Close Button scale",
             "internalName":"closeButtonScale",
             "editType":"float"
-        }],
-    "//addItemFunctionName":"",
-    "//removeItemFunctionName":"",
+        }
+    ],
+    "addItemNode": "canvas",
     "importPath":"from DirectGuiExtension.DirectScrolledWindowFrame import DirectScrolledWindowFrame"
 }

--- a/DesignerWidgets/DirectScrolledWindowFrame.widget
+++ b/DesignerWidgets/DirectScrolledWindowFrame.widget
@@ -1,39 +1,38 @@
 {
     "name":"DirectScrolledWindowFrame",
+    "baseWidget":"DirectScrolledFrame",
     "moduleName":"DirectScrolledWindowFrame",
     "displayName":"Scrolled Window Frame",
     "className":"DirectScrolledWindowFrame",
     "classfilePath":"DirectGuiExtension.DirectScrolledWindowFrame",
-    "enabledProperties":[""],
     "customProperties":[
         {
-            "displayName":"Drag Aea Height",
-            "propertyName":"dragAreaHeight",
-            "propertyType":"float"
+            "visiblename":"Drag Area Height",
+            "internalName":"dragAreaHeight",
+            "editType":"float"
         },
         {
-            "displayName":"Resort z-order on drag",
-            "propertyName":"resortOnDrag",
-            "propertyType":"bool"
+            "visiblename":"Resort z-order on drag",
+            "internalName":"resortOnDrag",
+            "editType":"bool"
         },
         {
-            "displayName":"Show Close Button",
-            "propertyName":"showClose",
-            "propertyType":"bool"
+            "visiblename":"Show Close Button",
+            "internalName":"showClose",
+            "editType":"bool"
         },
         {
-            "displayName":"Close Button Position",
-            "propertyName":"closeButtonPosition",
-            "propertyType":"selection",
-            "customSelectionDict":{"Left":"Left", "Right":"Right"}
-
+            "visiblename":"Close Button Position",
+            "internalName":"closeButtonPosition",
+            "editType":"optionmenu",
+            "valueOptions":{"Left":"Left", "Right":"Right"}
         },
         {
-            "displayName":"Close Button scale",
-            "propertyName":"closeButtonScale",
-            "propertyType":"float"
+            "visiblename":"Close Button scale",
+            "internalName":"closeButtonScale",
+            "editType":"float"
         }],
-    "addItemFunctionName":"",
-    "removeItemFunctionName":"",
+    "//addItemFunctionName":"",
+    "//removeItemFunctionName":"",
     "importPath":"from DirectGuiExtension.DirectScrolledWindowFrame import DirectScrolledWindowFrame"
 }

--- a/DesignerWidgets/DirectScrolledWindowFrame.widget
+++ b/DesignerWidgets/DirectScrolledWindowFrame.widget
@@ -31,6 +31,10 @@
             "displayName":"Close Button scale",
             "internalName":"closeButtonScale",
             "editType":"float"
+        },
+        {
+        "internalName": "scale",
+        "defaultPixel": 200
         }
     ],
     "addItemNode": "canvas",

--- a/DesignerWidgets/DirectSpinBox.widget
+++ b/DesignerWidgets/DirectSpinBox.widget
@@ -1,57 +1,64 @@
 {
     "name":"DirectSpinBox",
+    "baseWidget":"DirectFrame",
     "moduleName":"DirectSpinBox",
     "displayName":"Spinner",
     "className":"DirectSpinBox",
     "classfilePath":"DirectGuiExtension.DirectSpinBox",
-    "enabledProperties":[],
     "customProperties":[
     {
-        "displayName":"Step Size",
-        "propertyName":"stepSize",
-        "propertyType":"int"
+        "visiblename":"Value",
+        "internalName":"value",
+        "editType":"integer",
+        "setFunctionName":"setValue"
     },
     {
-        "displayName":"Reset Position",
-        "propertyName":"",
-        "propertyType":"command",
-        "customCommandName":"resetPosition"
+        "visiblename":"Reset Position",
+        "internalName":"",
+        "editType":"command",
+        "valueOptions":"resetPosition"
     },
     {
-        "displayName":"Recalculate Frame Size",
-        "propertyName":"",
-        "propertyType":"command",
-        "customCommandName":"recalcFrameSize"
+        "visiblename":"Recalculate Frame Size",
+        "internalName":"",
+        "editType":"command",
+        "valueOptions":"recalcFrameSize"
     },
     {
-        "displayName":"Text format",
-        "propertyName":"textFormat",
-        "propertyType":"text"
+        "visiblename":"Text format",
+        "internalName":"textFormat",
+        "editType":"text"
     },
     {
-        "displayName":"Minimum value",
-        "propertyName":"minValue",
-        "propertyType":"int"
+        "visiblename":"Minimum value",
+        "internalName":"minValue",
+        "editType":"integer"
     },
     {
-        "displayName":"Maximum value",
-        "propertyName":"maxValue",
-        "propertyType":"int"
+        "visiblename":"Maximum value",
+        "internalName":"maxValue",
+        "editType":"integer"
     },
     {
-        "displayName":"Button repeat delay",
-        "propertyName":"repeatdelay",
-        "propertyType":"float"
+        "visiblename":"Step Size",
+        "internalName":"stepSize",
+        "editType":"integer"
     },
     {
-        "displayName":"Button repeat start delay",
-        "propertyName":"repeatStartdelay",
-        "propertyType":"float"
+        "visiblename":"Button repeat delay",
+        "internalName":"repeatdelay",
+        "editType":"float"
     },
     {
-        "displayName":"Button Orientation",
-        "propertyName":"buttonOrientation",
-        "propertyType":"orientation"
+        "visiblename":"Button repeat start delay",
+        "internalName":"repeatStartdelay",
+        "editType":"float"
+    },
+    {
+        "visiblename":"Button Orientation",
+        "internalName":"buttonOrientation",
+        "editType":"optionmenu",
+        "valueOptions":{"Vertical":"vertical", "Vertical Inverted":"vertical_inverted", "Horizontal":"horizontal", "Horizontal Inverted":"horizontal_inverted"}
     }],
     "importPath":"from customWidgetSample.DirectSpinBox import DirectSpinBox"
 }

--- a/DesignerWidgets/DirectSpinBox.widget
+++ b/DesignerWidgets/DirectSpinBox.widget
@@ -64,6 +64,12 @@
         "editType":"optionMenu",
         "valueOptions":{"Vertical":"vertical", "Horizontal":"horizontal"},
         "postProcessFunctionName":"resetPosition"
-    }],
+    },
+    {
+        "internalName": "scale",
+        "defaultAspect": 0.1,
+        "defaultPixel": 100
+    }
+    ],
     "importPath":"from DirectGuiExtension.DirectSpinBox import DirectSpinBox"
 }

--- a/DesignerWidgets/DirectSpinBox.widget
+++ b/DesignerWidgets/DirectSpinBox.widget
@@ -1,64 +1,69 @@
 {
     "name":"DirectSpinBox",
-    "baseWidget":"DirectFrame",
     "moduleName":"DirectSpinBox",
     "displayName":"Spinner",
     "className":"DirectSpinBox",
-    "classfilePath":"DirectGuiExtension.DirectSpinBox",
+    "classFilePath":"DirectGuiExtension.DirectSpinBox",
+    "baseWidget": "DirectFrame",
     "customProperties":[
     {
-        "visiblename":"Value",
-        "internalName":"value",
-        "editType":"integer",
-        "setFunctionName":"setValue"
+        "displayName":"Step Size",
+        "internalName":"stepSize",
+        "editType":"float"
     },
     {
-        "visiblename":"Reset Position",
+        "displayName":"Reset Position",
         "internalName":"",
         "editType":"command",
         "valueOptions":"resetPosition"
     },
     {
-        "visiblename":"Recalculate Frame Size",
+        "displayName":"Recalculate Frame Size",
         "internalName":"",
         "editType":"command",
+        "internalType":"function",
         "valueOptions":"recalcFrameSize"
     },
     {
-        "visiblename":"Text format",
+        "displayName":"Text format",
         "internalName":"textFormat",
         "editType":"text"
     },
     {
-        "visiblename":"Minimum value",
+        "displayName":"value Type",
+        "internalName":"valueType",
+        "editType":"optionMenu",
+        "valueOptions":{"int":"int", "float":"float"},
+        "loaderFunc": "eval(value)",
+        "addToExtraOptions": true,
+        "canGetValueFromElement": false
+    },
+    {
+        "displayName":"Minimum value",
         "internalName":"minValue",
-        "editType":"integer"
+        "editType":"int"
     },
     {
-        "visiblename":"Maximum value",
+        "displayName":"Maximum value",
         "internalName":"maxValue",
-        "editType":"integer"
+        "editType":"int"
     },
     {
-        "visiblename":"Step Size",
-        "internalName":"stepSize",
-        "editType":"integer"
-    },
-    {
-        "visiblename":"Button repeat delay",
+        "displayName":"Button repeat delay",
         "internalName":"repeatdelay",
         "editType":"float"
     },
     {
-        "visiblename":"Button repeat start delay",
+        "displayName":"Button repeat start delay",
         "internalName":"repeatStartdelay",
         "editType":"float"
     },
     {
-        "visiblename":"Button Orientation",
+        "displayName":"Button Orientation",
         "internalName":"buttonOrientation",
-        "editType":"optionmenu",
-        "valueOptions":{"Vertical":"vertical", "Vertical Inverted":"vertical_inverted", "Horizontal":"horizontal", "Horizontal Inverted":"horizontal_inverted"}
+        "editType":"optionMenu",
+        "valueOptions":{"Vertical":"vertical", "Horizontal":"horizontal"},
+        "postProcessFunctionName":"resetPosition"
     }],
-    "importPath":"from customWidgetSample.DirectSpinBox import DirectSpinBox"
+    "importPath":"from DirectGuiExtension.DirectSpinBox import DirectSpinBox"
 }

--- a/DesignerWidgets/DirectSplitFrame.widget
+++ b/DesignerWidgets/DirectSplitFrame.widget
@@ -22,6 +22,13 @@
             "editType":"float"
         },
         {
+            "displayName":"Orientation",
+            "internalName":"orientation",
+            "editType":"optionMenu",
+            "valueOptions":{"Horizontal":"horizontal", "Vertical":"vertical"},
+            "postProcessFunctionName": "refresh"
+        },
+        {
             "displayName":"Splitter Color",
             "internalName":"splitterColor",
             "editType":"base4"
@@ -54,6 +61,6 @@
     ],
     "//addItemFunctionName":"addItem",
     "//removeItemFunctionName":"removeItem",
-    "addItemNode": "firstFrame",
+    "addItemNode": ["firstFrame", "secondFrame"],
     "importPath":"from DirectGuiExtension.DirectSplitFrame import DirectSplitFrame"
 }

--- a/DesignerWidgets/DirectSplitFrame.widget
+++ b/DesignerWidgets/DirectSplitFrame.widget
@@ -7,6 +7,11 @@
     "classFilePath":"DirectGuiExtension.DirectSplitFrame",
     "customProperties":[
         {
+            "displayName":"Pixel 2d",
+            "internalName":"pixel2d",
+            "editType":"bool"
+        },
+        {
             "displayName":"Show Splitter",
             "internalName":"showSplitter",
             "editType":"bool"
@@ -19,7 +24,8 @@
         {
             "displayName":"Splitter Width",
             "internalName":"splitterWidth",
-            "editType":"float"
+            "editType":"float",
+            "defaultPixel": 8
         },
         {
             "displayName":"Orientation",
@@ -57,6 +63,10 @@
             "displayName":"Second Frame Min Size",
             "internalName":"secondFrameMinSize",
             "editType":"float"
+        },
+        {
+        "internalName": "frameSize",
+        "defaultPixel": [-100, 100, -100, 100]
         }
     ],
     "//addItemFunctionName":"addItem",

--- a/DesignerWidgets/DirectSplitFrame.widget
+++ b/DesignerWidgets/DirectSplitFrame.widget
@@ -69,8 +69,6 @@
         "defaultPixel": [-100, 100, -100, 100]
         }
     ],
-    "//addItemFunctionName":"addItem",
-    "//removeItemFunctionName":"removeItem",
     "addItemNode": ["firstFrame", "secondFrame"],
     "importPath":"from DirectGuiExtension.DirectSplitFrame import DirectSplitFrame"
 }

--- a/DesignerWidgets/DirectSplitFrame.widget
+++ b/DesignerWidgets/DirectSplitFrame.widget
@@ -1,0 +1,59 @@
+{
+    "name":"DirectSplitFrame",
+    "baseWidget":"DirectFrame",
+    "moduleName":"DirectSplitFrame",
+    "displayName":"Split Frame",
+    "className":"DirectSplitFrame",
+    "classFilePath":"DirectGuiExtension.DirectSplitFrame",
+    "customProperties":[
+        {
+            "displayName":"Show Splitter",
+            "internalName":"showSplitter",
+            "editType":"bool"
+        },
+        {
+            "displayName":"Splitter Pos",
+            "internalName":"splitterPos",
+            "editType":"float"
+        },
+        {
+            "displayName":"Splitter Width",
+            "internalName":"splitterWidth",
+            "editType":"float"
+        },
+        {
+            "displayName":"Splitter Color",
+            "internalName":"splitterColor",
+            "editType":"base4"
+        },
+        {
+            "displayName":"Splitter Highlight Color",
+            "internalName":"splitterHighlightColor",
+            "editType":"base4"
+        },
+        {
+            "displayName":"First Frame Update Size Func",
+            "internalName":"firstFrameUpdateSizeFunc",
+            "internalType":"function"
+        },
+        {
+            "displayName":"Second Frame Update Size Func",
+            "internalName":"secondFrameUpdateSizeFunc",
+            "internalType":"function"
+        },
+        {
+            "displayName":"First Frame Min Size",
+            "internalName":"firstFrameMinSize",
+            "editType":"float"
+        },
+        {
+            "displayName":"Second Frame Min Size",
+            "internalName":"secondFrameMinSize",
+            "editType":"float"
+        }
+    ],
+    "//addItemFunctionName":"addItem",
+    "//removeItemFunctionName":"removeItem",
+    "addItemNode": "firstFrame",
+    "importPath":"from DirectGuiExtension.DirectSplitFrame import DirectSplitFrame"
+}

--- a/DesignerWidgets/DirectTabbedFrame.widget
+++ b/DesignerWidgets/DirectTabbedFrame.widget
@@ -37,7 +37,7 @@
         "defaultPixel": 100
         }
     ],
-    "addItemFunctionName":"add_tab",
+    "addItemFunctionName":"_add_tab",
     "//removeItemFunctionName":"close_tab",
     "addItemExtraArgs": {
         "tab_text": {

--- a/DesignerWidgets/DirectTabbedFrame.widget
+++ b/DesignerWidgets/DirectTabbedFrame.widget
@@ -38,7 +38,6 @@
         }
     ],
     "addItemFunctionName":"_add_tab",
-    "//removeItemFunctionName":"close_tab",
     "addItemExtraArgs": {
         "tab_text": {
             "type": "str",

--- a/DesignerWidgets/DirectTabbedFrame.widget
+++ b/DesignerWidgets/DirectTabbedFrame.widget
@@ -1,0 +1,45 @@
+{
+    "name":"DirectTabbedFrame",
+    "baseWidget":"DirectFrame",
+    "moduleName":"DirectTabbedFrame",
+    "displayName":"Tabbed Frame",
+    "className":"DirectTabbedFrame",
+    "classFilePath":"DirectGuiExtension.DirectTabbedFrame",
+    "customProperties":[
+        {
+            "displayName":"Tab Height",
+            "internalName":"tabHeight",
+            "editType":"float"
+        },
+        {
+            "displayName":"Show Close On Tabs",
+            "internalName":"showCloseOnTabs",
+            "editType":"bool"
+        },
+        {
+            "displayName":"Selected Tab Color",
+            "internalName":"selectedTabColor",
+            "editType":"base4"
+        },
+        {
+            "displayName":"Unselected Tab Color",
+            "internalName":"unselectedTabColor",
+            "editType":"base4"
+        },
+        {
+            "displayName":"Reposition Tabs",
+            "internalName":"reposition_tabs",
+            "editType":"command",
+            "valueOptions": "reposition_tabs"
+        }
+    ],
+    "addItemFunctionName":"add_tab",
+    "//removeItemFunctionName":"close_tab",
+    "addItemExtraArgs": {
+        "tab_text": {
+            "type": "str",
+            "defaultValue": "tab"
+        }
+    },
+    "importPath":"from DirectGuiExtension.DirectTabbedFrame import DirectTabbedFrame"
+}

--- a/DesignerWidgets/DirectTabbedFrame.widget
+++ b/DesignerWidgets/DirectTabbedFrame.widget
@@ -31,6 +31,10 @@
             "internalName":"reposition_tabs",
             "editType":"command",
             "valueOptions": "reposition_tabs"
+        },
+        {
+        "internalName": "scale",
+        "defaultPixel": 100
         }
     ],
     "addItemFunctionName":"add_tab",

--- a/DesignerWidgets/DirectTooltip.widget
+++ b/DesignerWidgets/DirectTooltip.widget
@@ -24,7 +24,5 @@
             "defaultPixel": 100
         }
     ],
-    "//addItemFunctionName": "addItem",
-    "//removeItemFunctionName": "removeItem",
     "importPath": "from DirectGuiExtension.DirectTooltip import DirectTooltip"
 }

--- a/DesignerWidgets/DirectTooltip.widget
+++ b/DesignerWidgets/DirectTooltip.widget
@@ -1,0 +1,25 @@
+{
+    "name": "DirectTooltip",
+    "baseWidget": "DirectLabel",
+    "moduleName": "DirectTooltip",
+    "displayName": "Tooltip",
+    "className": "DirectTooltip",
+    "classFilePath": "DirectGuiExtension.DirectTooltip",
+    "customProperties": [
+        {
+            "displayName": "Show",
+            "internalName": "show",
+            "editType": "command",
+            "valueOptions": "show"
+        },
+        {
+            "displayName": "Hide",
+            "internalName": "hide",
+            "editType": "command",
+            "valueOptions": "hide"
+        }
+    ],
+    "//addItemFunctionName": "addItem",
+    "//removeItemFunctionName": "removeItem",
+    "importPath": "from DirectGuiExtension.DirectTooltip import DirectTooltip"
+}

--- a/DesignerWidgets/DirectTooltip.widget
+++ b/DesignerWidgets/DirectTooltip.widget
@@ -17,6 +17,11 @@
             "internalName": "hide",
             "editType": "command",
             "valueOptions": "hide"
+        },
+        {
+            "internalName": "scale",
+            "defaultAspect": 0.1,
+            "defaultPixel": 100
         }
     ],
     "//addItemFunctionName": "addItem",

--- a/DesignerWidgets/DirectTreeView.widget
+++ b/DesignerWidgets/DirectTreeView.widget
@@ -30,7 +30,5 @@
             "valueOptions": "refreshTree"
         }
     ],
-    "//addItemFunctionName": "addItem",
-    "//removeItemFunctionName": "removeItem",
     "importPath": "from DirectGuiExtension.DirectTreeView import DirectTreeView"
 }

--- a/DesignerWidgets/DirectTreeView.widget
+++ b/DesignerWidgets/DirectTreeView.widget
@@ -1,0 +1,36 @@
+{
+    "name": "DirectTreeView",
+    "baseWidget": "DirectBoxSizer",
+    "moduleName": "DirectTreeView",
+    "displayName": "Tree View",
+    "className": "DirectTreeView",
+    "classFilePath": "DirectGuiExtension.DirectTreeView",
+    "customProperties": [
+        {
+            "displayName": "Image Collapse",
+            "internalName": "imageCollapse",
+            "editType": "str",
+            "isInitOption": true
+        },
+        {
+            "displayName": "Image Collapsed",
+            "internalName": "imageCollapsed",
+            "editType": "str",
+            "isInitOption": true
+        },
+        {
+            "displayName": "Indentation Width",
+            "internalName": "indentationWidth",
+            "editType": "float"
+        },
+        {
+            "displayName": "Refresh Tree",
+            "internalName": "refreshTree",
+            "editType": "command",
+            "valueOptions": "refreshTree"
+        }
+    ],
+    "//addItemFunctionName": "addItem",
+    "//removeItemFunctionName": "removeItem",
+    "importPath": "from DirectGuiExtension.DirectTreeView import DirectTreeView"
+}

--- a/DirectGuiExtension/DirectCollapsibleFrame.py
+++ b/DirectGuiExtension/DirectCollapsibleFrame.py
@@ -22,7 +22,7 @@ class DirectCollapsibleFrame(DirectFrame):
 
             ('collapseText',   'collapse >>', None),
             ('extendText',     'extend <<', None),
-            ("frameSize",      (-0.5, 0.5, -0.5, 0.5), self.setFrameSize)
+            ('frameSize',      (-0.5, 0.5, -0.5, 0.5), self.setFrameSize)
             )
         # Merge keyword options with default options
         self.defineoptions(kw, optiondefs)
@@ -30,12 +30,7 @@ class DirectCollapsibleFrame(DirectFrame):
         # Initialize superclasses
         DirectFrame.__init__(self, parent)
 
-        # Call option initialization functions
-        self.initialiseoptions(DirectCollapsibleFrame)
-
-        self.resetFrameSize()
-
-        self.originalFrameSize = self['frameSize']
+        frameSize = self['frameSize']
 
         # set up the header button to collapse/extend
         self.toggleCollapseButton = self.createcomponent(
@@ -44,14 +39,27 @@ class DirectCollapsibleFrame(DirectFrame):
             text=self['extendText'] if self['collapsed'] else self['collapseText'],
             text_scale=0.05,
             text_align=TextNode.ALeft,
-            text_pos=(DGH.getRealLeft(self)+0.02, DGH.getRealTop(self)-self['headerheight']/2.0),
+            text_pos=(frameSize[0]+0.02, frameSize[3]-self['headerheight']/2.0),
             borderWidth=(0.02, 0.02),
             relief=DGG.FLAT,
             pressEffect=False,
             frameSize = (
-                DGH.getRealLeft(self), DGH.getRealRight(self),
-                DGH.getRealTop(self)-self['headerheight'], DGH.getRealTop(self)),
+                frameSize[0], frameSize[1],
+                frameSize[3]-self['headerheight'], frameSize[3]),
             command=self.toggleCollapsed)
+
+        # Call option initialization functions
+        self.initialiseoptions(DirectCollapsibleFrame)
+
+        self.resetFrameSize()
+        self.updateFrameSize()
+
+        self.originalFrameSize = self['frameSize']
+
+    def addItem(self, element, *args):
+        print(element)
+        for arg in args:
+            print(type(arg), arg)
 
     def updateFrameSize(self):
         self.toggleCollapseButton['frameSize'] = (

--- a/DirectGuiExtension/DirectCollapsibleFrame.py
+++ b/DirectGuiExtension/DirectCollapsibleFrame.py
@@ -56,11 +56,6 @@ class DirectCollapsibleFrame(DirectFrame):
 
         self.originalFrameSize = self['frameSize']
 
-    def addItem(self, element, *args):
-        print(element)
-        for arg in args:
-            print(type(arg), arg)
-
     def updateFrameSize(self):
         self.toggleCollapseButton['frameSize'] = (
             DGH.getRealLeft(self), DGH.getRealRight(self),

--- a/DirectGuiExtension/DirectCollapsibleFrame.py
+++ b/DirectGuiExtension/DirectCollapsibleFrame.py
@@ -21,7 +21,8 @@ class DirectCollapsibleFrame(DirectFrame):
             ('collapsed',           False, self.setCollapsed),
 
             ('collapseText',   'collapse >>', None),
-            ('extendText',     'extend <<', None)
+            ('extendText',     'extend <<', None),
+            ("frameSize",      (-0.5, 0.5, -0.5, 0.5), self.setFrameSize)
             )
         # Merge keyword options with default options
         self.defineoptions(kw, optiondefs)
@@ -57,6 +58,7 @@ class DirectCollapsibleFrame(DirectFrame):
             DGH.getRealLeft(self), DGH.getRealRight(self),
             DGH.getRealTop(self)-self['headerheight'], DGH.getRealTop(self))
         self.originalFrameSize = self['frameSize']
+        self.toggleCollapseButton["text_pos"] = (DGH.getRealLeft(self)+0.02, DGH.getRealTop(self)-self['headerheight']/2.0)
 
     def toggleCollapsed(self):
         self['collapsed'] = not self['collapsed']

--- a/DirectGuiExtension/DirectDatePicker.py
+++ b/DirectGuiExtension/DirectDatePicker.py
@@ -24,7 +24,7 @@ class DirectDatePicker(DirectGridSizer):
             ('normalDayFrameColor', None, None),
             ('activeDayFrameColor', None, None),
             ('todayFrameColor', None, None),
-
+            ('frameSize',       (-1, 1, -1, 1),  self.setFrameSize)
             # Define type of DirectGuiWidget
             )
         # Merge keyword options with default options
@@ -32,9 +32,6 @@ class DirectDatePicker(DirectGridSizer):
 
         # Initialize superclasses
         DirectGridSizer.__init__(self, parent, numRows=7, numColumns=8, autoUpdateFrameSize=True, itemMargin=[0.005, 0.005, 0.005, 0.005])
-
-        # Call option initialization functions
-        self.initialiseoptions(DirectDatePicker)
 
         # set up the calendar
         self.cal = calendar.Calendar()
@@ -91,9 +88,6 @@ class DirectDatePicker(DirectGridSizer):
                 self.addItem(btn, row, column)
                 day += 1
 
-        self.ll = Point3(self["frameSize"][0], self["frameSize"][2])
-        self.ur = Point3(self["frameSize"][1], self["frameSize"][3])
-
         # the year picker
         self.yearPicker = self.createcomponent(
             'yearPicker', (), None,
@@ -110,10 +104,6 @@ class DirectDatePicker(DirectGridSizer):
             decButtonCallback=self.__changedYear,
             command=self.__changedYear)
         self.yearPicker.resetFrameSize()
-        self.yearPicker.setPos(
-            DGH.getRealLeft(self) + DGH.getRealWidth(self.yearPicker)/2,
-            0,
-            DGH.getRealTop(self) - DGH.getRealBottom(self.yearPicker))
 
         self.monthPicker = self.createcomponent(
             'monthPicker', (), None,
@@ -124,11 +114,21 @@ class DirectDatePicker(DirectGridSizer):
             relief=DGG.FLAT)
         self.monthPicker.resetFrameSize()
 
+        # Call option initialization functions
+        self.initialiseoptions(DirectDatePicker)
+
+        self.ll = Point3(self["frameSize"][0], self["frameSize"][2])
+        self.ur = Point3(self["frameSize"][1], self["frameSize"][3])
+
+        self.yearPicker.setPos(
+            DGH.getRealLeft(self) + DGH.getRealWidth(self.yearPicker) / 2,
+            0,
+            DGH.getRealTop(self) - DGH.getRealBottom(self.yearPicker))
+
         self.monthPicker.setPos(
             DGH.getRealRight(self) - DGH.getRealWidth(self.monthPicker),
             0,
             DGH.getRealTop(self) - DGH.getRealBottom(self.monthPicker) / 2)
-
 
         # set the current date if none is given at initialization
         self['year'] = now.year if self['year'] is None else self['year']

--- a/DirectGuiExtension/DirectDiagram.py
+++ b/DirectGuiExtension/DirectDiagram.py
@@ -15,10 +15,10 @@ class DirectDiagram(DirectFrame):
     def __init__(self, parent = None, **kw):
         optiondefs = (
             # Define type of DirectGuiWidget
-            ('data',           [1, -2, 3],  self.refresh),
-            ('numPosSteps',     4,          self.refresh),
+            ('data',           [],  self.refresh),
+            ('numPosSteps',     1,          self.refresh),
             ('numPosStepsStep', 1,          self.refresh),
-            ('numNegSteps',     4,          self.refresh),
+            ('numNegSteps',     1,          self.refresh),
             ('numNegStepsStep', 1,          self.refresh),
             ('numtextScale',    0.05,       self.refresh),
             ('showDataNumbers', False,      self.refresh),

--- a/DirectGuiExtension/DirectDiagram.py
+++ b/DirectGuiExtension/DirectDiagram.py
@@ -16,9 +16,9 @@ class DirectDiagram(DirectFrame):
         optiondefs = (
             # Define type of DirectGuiWidget
             ('data',           [],  self.refresh),
-            ('numPosSteps',     1,          self.refresh),
+            ('numPosSteps',     0,          self.refresh),
             ('numPosStepsStep', 1,          self.refresh),
-            ('numNegSteps',     1,          self.refresh),
+            ('numNegSteps',     0,          self.refresh),
             ('numNegStepsStep', 1,          self.refresh),
             ('numtextScale',    0.05,       self.refresh),
             ('showDataNumbers', False,      self.refresh),
@@ -62,9 +62,22 @@ class DirectDiagram(DirectFrame):
         right = DGH.getRealRight(self)
         diagramLeft = left + textLeftSizeArea
 
+        # If there is no data we can not calculate 'numPosSteps' and 'numNegSteps'
+        if not self["data"] and self["numPosSteps"] <= 0:
+            numPosSteps = 5
+        else:
+            numPosSteps = self['numPosSteps']
+
+        if not self["data"] and self["numNegSteps"] <= 0:
+            numNegSteps = 5
+        else:
+            numNegSteps = self['numNegSteps']
+
         xStep = (DGH.getRealWidth(self) - textLeftSizeArea) / max(1, len(self['data'])-1)
-        posYRes = DGH.getRealTop(self) / (self['numPosSteps'] if self['numPosSteps'] > 0 else int(max(self['data'])))
-        negYRes = DGH.getRealBottom(self) / (-self['numNegSteps'] if self['numNegSteps'] > 0 else int(min(self['data'])))
+        posYRes = numPosSteps if numPosSteps > 0 else int(max(self['data']))
+        posYRes = DGH.getRealTop(self) / (posYRes if posYRes != 0 else 1)
+        negYRes = -numNegSteps if numNegSteps > 0 else int(min(self['data']))
+        negYRes = DGH.getRealBottom(self) / (negYRes if negYRes != 0 else 1)
 
         # remove old content
         if self.lines is not None:
@@ -107,7 +120,7 @@ class DirectDiagram(DirectFrame):
 
         # calculate the positive measure lines and add the numbers
         measureLineData = []
-        numSteps = (self['numPosSteps'] if self['numPosSteps'] >0 else math.floor(max(self['data']))) + 1
+        numSteps = (numPosSteps if numPosSteps > 0 else math.floor(max(self['data']))) + 1
         for i in range(1, numSteps, self['numPosStepsStep']):
             measureLineData.append(
                 (
@@ -117,7 +130,7 @@ class DirectDiagram(DirectFrame):
             )
 
             calcBase = 1 / DGH.getRealTop(self)
-            maxData = self['numPosSteps'] if self['numPosSteps'] >0 else max(self['data'])
+            maxData = numPosSteps if numPosSteps > 0 else max(self['data'])
             value = self['stepFormat'](round(i * posYRes * calcBase * maxData, self['stepAccuracy']))
             y = i*posYRes
             self.xDescriptions.append(
@@ -132,7 +145,7 @@ class DirectDiagram(DirectFrame):
                     state = 'normal'))
 
         # calculate the negative measure lines and add the numbers
-        numSteps = (self['numNegSteps'] if self['numNegSteps'] >0 else math.floor(abs(min(self['data'])))) + 1
+        numSteps = (numNegSteps if numNegSteps > 0 else math.floor(abs(min(self['data'])))) + 1
         for i in range(1, numSteps, self['numNegStepsStep']):
             measureLineData.append(
                 (
@@ -142,7 +155,7 @@ class DirectDiagram(DirectFrame):
             )
 
             calcBase = 1 / DGH.getRealBottom(self)
-            maxData = self['numPosSteps'] if self['numPosSteps'] >0 else max(self['data'])
+            maxData = numPosSteps if numPosSteps > 0 else max(self['data'])
             value = self['stepFormat'](round(i * negYRes * calcBase * maxData, self['stepAccuracy']))
             y = -i*negYRes
             self.xDescriptions.append(

--- a/DirectGuiExtension/DirectDiagram.py
+++ b/DirectGuiExtension/DirectDiagram.py
@@ -44,6 +44,12 @@ class DirectDiagram(DirectFrame):
         # Call option initialization functions
         self.initialiseoptions(DirectDiagram)
 
+    def setData(self, data):
+        self["data"] += [float(value) for value in data]
+        self["numPosSteps"] = max(self["data"])
+        self["numNegSteps"] = min(self["data"])
+        self.refresh()
+
 
     def refresh(self):
         # sanity check so we don't get here to early
@@ -56,9 +62,9 @@ class DirectDiagram(DirectFrame):
         right = DGH.getRealRight(self)
         diagramLeft = left + textLeftSizeArea
 
-        xStep = (DGH.getRealWidth(self) - textLeftSizeArea) / (len(self['data'])-1)
-        posYRes = DGH.getRealTop(self) / (self['numPosSteps'] if self['numPosSteps'] > 0 else max(self['data']))
-        negYRes = DGH.getRealBottom(self) / (-self['numNegSteps'] if self['numNegSteps'] > 0 else min(self['data']))
+        xStep = (DGH.getRealWidth(self) - textLeftSizeArea) / max(1, len(self['data'])-1)
+        posYRes = DGH.getRealTop(self) / (self['numPosSteps'] if self['numPosSteps'] > 0 else int(max(self['data'])))
+        negYRes = DGH.getRealBottom(self) / (-self['numNegSteps'] if self['numNegSteps'] > 0 else int(min(self['data'])))
 
         # remove old content
         if self.lines is not None:

--- a/DirectGuiExtension/DirectDiagram.py
+++ b/DirectGuiExtension/DirectDiagram.py
@@ -15,10 +15,10 @@ class DirectDiagram(DirectFrame):
     def __init__(self, parent = None, **kw):
         optiondefs = (
             # Define type of DirectGuiWidget
-            ('data',           [],          self.refresh),
-            ('numPosSteps',     0,          self.refresh),
+            ('data',           [1, -2, 3],  self.refresh),
+            ('numPosSteps',     4,          self.refresh),
             ('numPosStepsStep', 1,          self.refresh),
-            ('numNegSteps',     0,          self.refresh),
+            ('numNegSteps',     4,          self.refresh),
             ('numNegStepsStep', 1,          self.refresh),
             ('numtextScale',    0.05,       self.refresh),
             ('showDataNumbers', False,      self.refresh),
@@ -28,6 +28,7 @@ class DirectDiagram(DirectFrame):
             ('numberAreaWidth', 0.15,          self.refresh),
             #('numStates',      1,           None),
             #('state',          DGG.NORMAL,  None),
+            ("frameSize",       (-0.5, 0.5, -0.5, 0.5), self.setFrameSize)
             )
         # Merge keyword options with default options
         self.defineoptions(kw, optiondefs)
@@ -44,12 +45,11 @@ class DirectDiagram(DirectFrame):
         # Call option initialization functions
         self.initialiseoptions(DirectDiagram)
 
-    def setData(self, data):
-        self["data"] += [float(value) for value in data]
-        self["numPosSteps"] = max(self["data"])
-        self["numNegSteps"] = min(self["data"])
         self.refresh()
 
+    def setData(self, data):
+        self["data"] = [float(value) for value in data]
+        self.refresh()
 
     def refresh(self):
         # sanity check so we don't get here to early

--- a/DirectGuiExtension/DirectOptionMenu.py
+++ b/DirectGuiExtension/DirectOptionMenu.py
@@ -221,7 +221,9 @@ class DirectOptionMenu(DirectButton):
         # Needed attributes (such as minZ) won't be set unless the user has specified
         # items to display. Let's assert that we've given items to work with.
         items = self['items']
-        assert items and len(items) > 0, 'Cannot show an empty popup menu! You must add items!'
+        # assert items and len(items) > 0, 'Cannot show an empty popup menu! You must add items!'
+        if not items:
+            return
 
         # Show the menu
         self.popupMenu.show()

--- a/DirectGuiExtension/DirectScrolledWindowFrame.py
+++ b/DirectGuiExtension/DirectScrolledWindowFrame.py
@@ -31,13 +31,10 @@ class DirectScrolledWindowFrame(DirectScrolledFrame):
         # Initialize superclasses
         DirectScrolledFrame.__init__(self, parent)
 
-        # Call option initialization functions
-        self.initialiseoptions(DirectScrolledWindowFrame)
-
         self.dragDropTask = None
 
-        b = self.bounds
-        c = self.createcomponent(
+        b = self["frameSize"]
+        self.dragFrame = self.createcomponent(
             'dragFrame', (), 'dragFrame',
             DirectFrame,
             # set the parent of the frame to this class
@@ -50,8 +47,8 @@ class DirectScrolledWindowFrame(DirectScrolledFrame):
             # set the size
             frameSize=(b[0],b[1],0, self['dragAreaHeight']))
 
-        c.bind(DGG.B1PRESS, self.dragStart)
-        c.bind(DGG.B1RELEASE, self.dragStop)
+        self.dragFrame.bind(DGG.B1PRESS, self.dragStart)
+        self.dragFrame.bind(DGG.B1RELEASE, self.dragStop)
 
         scale = self['closeButtonScale']
         pos = (0,0,self['dragAreaHeight']*0.5)
@@ -59,14 +56,20 @@ class DirectScrolledWindowFrame(DirectScrolledFrame):
             pos = (b[1]-scale*0.5,0,self['dragAreaHeight']*0.5)
         elif self['closeButtonPosition'] == 'Left':
             pos = (b[0]+scale*0.5,0,self['dragAreaHeight']*0.5)
-        closeBtn = self.createcomponent(
+        self.closeButton = self.createcomponent(
             'closeButton', (), 'closeButton',
             DirectButton,
-            (c,),
+            (self.dragFrame,),
             text='x',
             scale=scale,
             pos=pos,
             command=self.destroy)
+
+        # Call option initialization functions
+        self.initialiseoptions(DirectScrolledWindowFrame)
+
+        self.dragFrame.setPos(0, 0, self.bounds[3])
+        self.dragFrame["frameSize"] = (self.bounds[0], self.bounds[1], 0, self['dragAreaHeight'])
 
     def dragStart(self, event):
         """

--- a/DirectGuiExtension/DirectSplitFrame.py
+++ b/DirectGuiExtension/DirectSplitFrame.py
@@ -61,6 +61,7 @@ class DirectSplitFrame(DirectFrame):
             ('secondFrameMinSize', None,    None),
 
             ('suppressMouse',  0,           None),
+            ("frameSize",      (-0.5, 0.5, -0.5, 0.5), self.setFrameSize)
             )
         # Merge keyword options with default options
         self.defineoptions(kw, optiondefs)

--- a/DirectGuiExtension/DirectSplitFrame.py
+++ b/DirectGuiExtension/DirectSplitFrame.py
@@ -44,7 +44,7 @@ class DirectSplitFrame(DirectFrame):
             ('state',          DGG.NORMAL,  None),
             ('borderWidth',    (0, 0),      self.setBorderWidth),
             ('orientation', DGG.HORIZONTAL, self.refresh),
-            ('framesize',      (-1,1,-1,1), None),
+            ('frameSize',      (-1,1,-1,1), None),
 
             # TODO: Change this. This only works for certain circumstances
             ('pixel2d',        False,       self.refresh),
@@ -60,17 +60,13 @@ class DirectSplitFrame(DirectFrame):
             ('firstFrameMinSize', None,     None),
             ('secondFrameMinSize', None,    None),
 
-            ('suppressMouse',  0,           None),
-            ("frameSize",      (-0.5, 0.5, -0.5, 0.5), self.setFrameSize)
+            ('suppressMouse',  0,           None)
             )
         # Merge keyword options with default options
         self.defineoptions(kw, optiondefs)
 
         # Initialize superclasses
         DirectFrame.__init__(self, parent)
-
-        # Call option initialization functions
-        self.initialiseoptions(DirectSplitFrame)
 
         self.resetFrameSize()
 
@@ -99,6 +95,10 @@ class DirectSplitFrame(DirectFrame):
             text_scale = 0.05,
             text_align = TextNode.ACenter,
             state = 'normal')
+
+        # Call option initialization functions
+        self.initialiseoptions(DirectSplitFrame)
+
         self.splitter.bind(DGG.ENTER, self.enter)
         self.splitter.bind(DGG.EXIT, self.exit)
         self.splitter.bind(DGG.B1PRESS, self.dragStart)

--- a/DirectGuiExtension/DirectSplitFrame.py
+++ b/DirectGuiExtension/DirectSplitFrame.py
@@ -62,6 +62,9 @@ class DirectSplitFrame(DirectFrame):
 
             ('suppressMouse',  0,           None)
             )
+
+        self._splitterWidth = 0
+
         # Merge keyword options with default options
         self.defineoptions(kw, optiondefs)
 
@@ -104,21 +107,22 @@ class DirectSplitFrame(DirectFrame):
         self.splitter.bind(DGG.B1PRESS, self.dragStart)
         self.splitter.bind(DGG.B1RELEASE, self.dragStop)
 
-        self.setSplitter(self['splitterWidth'])
+        self.setSplitter()
 
         self.skipInitRefresh = False
         # initialize once at the end
         self.refresh()
 
-    def setSplitter(self, width=0.02):
+    def setSplitter(self):
         if not hasattr(self, "splitter"): return
         if self['showSplitter'] == False:
             self.splitter.hide()
+            self._splitterWidth = self["splitterWidth"]
             self['splitterWidth'] = 0
         else:
             self.splitter.show()
-            self['splitterWidth'] = width
-
+            if self["splitterWidth"] == 0:
+                self['splitterWidth'] = self._splitterWidth
 
     def refresh(self):
         """

--- a/DirectGuiExtension/DirectSplitFrame.py
+++ b/DirectGuiExtension/DirectSplitFrame.py
@@ -134,6 +134,7 @@ class DirectSplitFrame(DirectFrame):
 
         if self["orientation"] == DGG.HORIZONTAL:
             self.splitter.setX(self["splitterPos"])
+            self.splitter.setZ(0)
             self.checkMinSIze()
 
             if self["pixel2d"]:
@@ -156,6 +157,7 @@ class DirectSplitFrame(DirectFrame):
 
         elif self["orientation"] == DGG.VERTICAL:
             self.splitter.setZ(self["splitterPos"])
+            self.splitter.setX(0)
             self.checkMinSIze()
 
             if self["pixel2d"]:

--- a/DirectGuiExtension/DirectTabbedFrame.py
+++ b/DirectGuiExtension/DirectTabbedFrame.py
@@ -92,7 +92,7 @@ class DirectTabbedFrame(DirectFrame):
             self.start_idx += 1
             self.reposition_tabs()
 
-    def add_tab(self, tab_text, content, close_func=None):
+    def add_tab(self, content, tab_text, close_func=None):
         # create the new tab
         tab = self.createcomponent(
             'tab', (), 'tab',

--- a/DirectGuiExtension/DirectTabbedFrame.py
+++ b/DirectGuiExtension/DirectTabbedFrame.py
@@ -92,7 +92,10 @@ class DirectTabbedFrame(DirectFrame):
             self.start_idx += 1
             self.reposition_tabs()
 
-    def add_tab(self, content, tab_text, close_func=None):
+    def _add_tab(self, content, tab_text, close_func=None):  # method used by DirectGuiDesigner to add tabs
+        self.add_tab(tab_text, content, close_func)
+
+    def add_tab(self, tab_text, content, close_func=None):
         # create the new tab
         tab = self.createcomponent(
             'tab', (), 'tab',

--- a/DirectGuiExtension/DirectTooltip.py
+++ b/DirectGuiExtension/DirectTooltip.py
@@ -93,15 +93,18 @@ class DirectTooltip(DirectLabel):
             if self.getParent() == base.pixel2d:
                 x = base.win.getPointer(0).getX()
                 y = -base.win.getPointer(0).getY()
+                # set the text to the current mouse position
+                self.setPos(x + self.textXShift,
+                            0,
+                            y + self.textYShift)
             else:
                 x = (base.mouseWatcherNode.getMouseX()*aspX)
                 y = (base.mouseWatcherNode.getMouseY()*aspY)
-
-            # set the text to the current mouse position
-            self.setPos(
-                x + self.textXShift,
-                0,
-                y + self.textYShift)
+                # set the text to the current mouse position
+                self.setPos(base.aspect2d,
+                            x + self.textXShift,
+                            0,
+                            y + self.textYShift)
 
             bounds = self.getBounds()
             # bounds = left, right, bottom, top


### PR DESCRIPTION
This PR aims to make the widgets in DirectGuiExtension work with the DirectGuiDesigner. The old .widget files have been updated to work with the current version (with the changes from my PR Custom Widgets) of DirectGuiDesigner and the missing .widget files have been added. 

In some places I have changed stuff in the widgets themselves to make them work better with the designer, but some of these changes are API breaking. Do you think that is fine? Or how should that be handled?

There is still a number of things to fix to make this work well, but all widgets can be created in the designer and most properties can be edited.